### PR TITLE
Only recalculate styles and css props if the resolve and create functions in the stylesInterface have changed.

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -99,9 +99,11 @@ export function withStyles(
   function makeCreateFn(direction, stylesInterface) {
     const directionSelector = direction === DIRECTIONS.RTL ? 'RTL' : 'LTR';
     let create = stylesInterface[`create${directionSelector}`] || stylesInterface.create;
+    const original = create;
     if (process.env.NODE_ENV !== 'production') {
       create = withPerf('create')(create);
     }
+    create.original = original;
     return create;
   }
 
@@ -109,9 +111,11 @@ export function withStyles(
   function makeResolveFn(direction, stylesInterface) {
     const directionSelector = direction === DIRECTIONS.RTL ? 'RTL' : 'LTR';
     let resolve = stylesInterface[`resolve${directionSelector}`] || stylesInterface.resolve;
+    const original = resolve;
     if (process.env.NODE_ENV !== 'production') {
       resolve = withPerf('resolve')(resolve);
     }
+    resolve.original = original;
     return resolve;
   }
 
@@ -169,15 +173,23 @@ export function withStyles(
           || componentCache.create;
         const resolve = (interfaceChanged && makeResolveFn(direction, stylesInterface))
           || componentCache.resolve;
-        // Derive the css function prop
-        const css = (interfaceChanged && ((...args) => resolve(args)))
+
+        // Determine if create or resolve functions have changed, which will then
+        // determine if we need to create new css or style props
+        const createChanged = !componentCache || !componentCache.create
+          || create.original !== componentCache.create.original;
+        const resolveChanged = !componentCache || !componentCache.resolve
+          || resolve.original !== componentCache.resolve.original;
+
+        // Derive the css function prop: recalculate it if resolve changed
+        const css = (resolveChanged && ((...args) => resolve(args)))
           || componentCache.props.css;
         // Get or calculate the themed styles from the stylesFn:
         // Uses a separate cache at the component level, not at the instance level,
         // to only apply the theme to the stylesFn once per component class per theme.
         const stylesFnResult = getOrCreateStylesFnResultCache(theme);
         // Derive the styles prop: recalculate it if create changed, or stylesFnResult changed
-        const styles = ((interfaceChanged || stylesFnResult !== componentCache.stylesFnResult)
+        const styles = ((createChanged || stylesFnResult !== componentCache.stylesFnResult)
           && create(stylesFnResult))
           || componentCache.props.styles;
         // Put the new props together

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -390,6 +390,7 @@ describe('withStyles', () => {
           primary: false,
         };
 
+        TestHelper.MockComponent = MockComponent;
         return TestHelper;
       }
 
@@ -490,6 +491,62 @@ describe('withStyles', () => {
           </div>,
         );
         expect(stylesFn).to.have.property('callCount', 1);
+      });
+
+      describe('create/resolve change detection', () => {
+        let thirdInterface;
+
+        beforeEach(() => {
+          const {
+            resolve, resolveRTL, resolveLTR, create, createRTL, createLTR,
+          } = mockInterface();
+          secondInterface = {
+            ...firstInterface,
+            // non-identical resolve functions
+            resolve,
+            resolveRTL,
+            resolveLTR,
+          };
+          thirdInterface = {
+            ...firstInterface,
+            // non-identical create functions
+            create,
+            createRTL,
+            createLTR,
+          };
+        });
+
+        it('does not create a new css prop if interface changes but the resolve functions dont\'t', () => {
+          const TestHelper = makeTestHelper();
+          const wrapper = mount(<TestHelper />);
+
+          const css = wrapper.find(TestHelper.MockComponent).prop('css');
+
+          // css prop should remain the same
+          wrapper.setProps({ stylesInterface: thirdInterface });
+          expect(wrapper.find(TestHelper.MockComponent).prop('css')).to.equal(css);
+
+          // css prop should now be different
+          wrapper.setProps({ stylesInterface: secondInterface });
+          expect(wrapper.find(TestHelper.MockComponent).prop('css')).not.to.equal(css);
+        });
+
+        it('does not create re-create stylesheets if interface changes but the create function don\'t', () => {
+          const TestHelper = makeTestHelper();
+          const wrapper = mount(<TestHelper direction="ltr" />);
+
+          expect(secondInterface.createLTR).to.have.property('callCount', 1);
+          secondInterface.createLTR.resetHistory(); // reset spy count
+          expect(secondInterface.createLTR).to.have.property('callCount', 0);
+
+          // create is the same, so it shouldn't be called
+          wrapper.setProps({ stylesInterface: secondInterface });
+          expect(secondInterface.createLTR).to.have.property('callCount', 0);
+
+          // create is different, so it should be called
+          wrapper.setProps({ stylesInterface: thirdInterface });
+          expect(thirdInterface.createLTR).to.have.property('callCount', 1);
+        });
       });
     });
 


### PR DESCRIPTION
The `styles` and `css` props are always recalculated  when the style interface changes. This creates excessive performance problems when you want to implement a semi dynamic interface that only changes the `create` methods or the `resolve` methods. 

Instead of recreating both props when the interface changes, only do so if the respective method used from the interface has changed.

Now, when the style interface changes:
- Only recalculate `styles` prop if the (appropriate direction) `create` function changes.
- Only recreate `css` prop if when the (appropriate direction) `resolve` function changes.